### PR TITLE
Agregando refresh_field para items

### DIFF
--- a/factura_electronica/public/js/facelec.js
+++ b/factura_electronica/public/js/facelec.js
@@ -1,4 +1,5 @@
 facelec_tax_calculation = function(frm, cdt, cdn) {
+    refresh_field('items');
     var this_row_qty, this_row_rate, this_row_amount, this_row_conversion_factor, this_row_stock_qty, this_row_tax_rate, this_row_tax_amount, this_row_taxable_amount;
 
     frm.doc.items.forEach((item_row, index) => {

--- a/factura_electronica/public/js/facelec.min.js
+++ b/factura_electronica/public/js/facelec.min.js
@@ -1,6 +1,7 @@
 
 
 facelec_tax_calculation = function facelec_tax_calculation(frm, cdt, cdn) {
+    refresh_field('items');
     var this_row_qty, this_row_rate, this_row_amount, this_row_conversion_factor, this_row_stock_qty, this_row_tax_rate, this_row_tax_amount, this_row_taxable_amount;
 
     frm.doc.items.forEach(function (item_row, index) {


### PR DESCRIPTION
Se agregó `refresh_field('items');` para actualizar los datos antes de realizar los cálculos, descartando los cambios anteriores, para unos nuevos.